### PR TITLE
Restored filtering support for JednostkaAdministracyjnaViewSet

### DIFF
--- a/teryt_tree/rest_framework_ext/viewsets.py
+++ b/teryt_tree/rest_framework_ext/viewsets.py
@@ -33,4 +33,4 @@ class JednostkaAdministracyjnaViewSet(viewsets.ModelViewSet):
     )
     serializer_class = JednostkaAdministracyjnaSerializer
     filter_backends = (filters.DjangoFilterBackend,)
-    filter_class = JednostkaAdministracyjnaFilter
+    filterset_class = JednostkaAdministracyjnaFilter


### PR DESCRIPTION
Since some time `JednostkaAdministracyjnaViewSet` doesn't support filtering, as can be tested here:
https://fedrowanie.siecobywatelska.pl/api/teryt/?name=%C5%9Al%C4%85skie
This causes errors on https://sprawdzamyjakjest.pl because this project uses Feder API to build URLs to redirect to.

`django-filter` app requires `FilterSet` class to be assigned as `filterset_class`, otherwise it's ignored.

So, please merge the pull request or do an update accordingly and also update `watchdogpolska/feder` to use fixed `djangoteryt-tree` version.

Thank you.